### PR TITLE
Allows bruteforce of keys that already in gpg keyring but have been forgotten to passpharse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+GPGMELIBS := $(shell pkg-config --libs gpgme)
+
 bruteforce-gpg: src/main.c bruteforce_gpg.o log.o agent.o
-	gcc -pthread -l gpgme -o bruteforce-gpg src/main.c bruteforce_gpg.o log.o agent.o
+	gcc -o bruteforce-gpg  src/main.c bruteforce_gpg.o log.o agent.o -pthread $(GPGMELIBS)
 bruteforce_gpg.o: src/bruteforce_gpg.c src/bruteforce_gpg.h
 	gcc -c src/bruteforce_gpg.c -o bruteforce_gpg.o
 agent.o: src/agent.c src/agent.h
@@ -7,6 +9,6 @@ agent.o: src/agent.c src/agent.h
 log.o: src/log.c src/log.h
 	gcc -c src/log.c -o log.o
 clean:
-	rm --force bruteforce-gpg bruteforce_gpg.o log.o
+	rm --force bruteforce-gpg *.o
 install:
 	install bruteforce-gpg /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ bruteforce-gpg [-h] [-v] [-t NUM_THREADS] -f WORDLIST GPG_SECRET_KEY
 ## Setup
 ### 1. Install Dependencies
 
-This tool depends on the [libgpgme](https://www.gnupg.org/software/gpgme/index.html) library.
+This tool depends on the [libgpgme](https://www.gnupg.org/software/gpgme/index.html) library and [pkg-config](http://pkg-config.freedesktop.org) tool.
 
 On Kali
 ```bash
-$ sudo apt install libgpgme-dev
+$ sudo apt install libgpgme-dev pkg-config
 ```
 
 On Arch Linux
 ```bash
-$ sudo pacman -S gpgme
+$ sudo pacman -S gpgme pkg-config
 ```
 
 ### 2. Download
@@ -41,7 +41,7 @@ $ make
 `bruteforce-gpg` will be installed in the `/usr/local/bin/` directory, so you may want to ensure it is included in your `PATH` environment variable.
 
 ```bash
-make install
+# make install
 ```
 
 ## Examples

--- a/src/bruteforce_gpg.h
+++ b/src/bruteforce_gpg.h
@@ -1,13 +1,15 @@
-#include <gpgme.h>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <stdio.h>
-#include <pthread.h>
 #include <time.h>
+
+#include <pthread.h>
+#include <gpgme.h>
+
 #include "log.h"
 
-#define USAGE "%s [-h] [-v] [-t NUM_THREADS] -f WORDLIST GPG_SECRET_KEY\n"
+#define USAGE "%s [-h] [-v] [-t NUM_THREADS] -f WORDLIST GPG_SECRET_KEYFILE | FINGERPRINT\n"
 #define ERR_BUF_LEN 500
 
 struct callback_data {
@@ -27,5 +29,6 @@ struct thread_args {
   char *passphrase;
 };
 
-char *bruteforce_gpg_load_secret_key(char *secret_key_filename, char **fingerprint);
+char *bruteforce_gpg_import_secret_key(char *secret_key_filename, char **fingerprint);
+bool bruteforce_gpg_delete_secret_key(char const *fingerprint);
 void *bruteforce_gpg_crack_passphrase(void *args);

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,7 @@
 #include <getopt.h>
+#include <unistd.h>
+#include <stdbool.h>
+
 #include "bruteforce_gpg.h"
 #include "log.h"
 #include "agent.h"
@@ -14,12 +17,13 @@ int main(int argc, char *argv[argc])
 {
   int option;
   long num_threads;
-  char *password_filename = NULL, *secret_key_filename, *endptr, *ttl = NULL;
+  char *password_filename = NULL, *secret_key, *endptr, *ttl = NULL;
   pthread_t *workers;
   gpgme_error_t err;
   void *worker_err;
   struct thread_args gpg_data;
   time_t start_time;
+  bool import_keyfile = false;
 
   num_threads = 1;
   debug = opterr = 0;
@@ -60,11 +64,13 @@ int main(int argc, char *argv[argc])
     fprintf(stderr, USAGE, argv[0]);
     exit(1);
   }
-  secret_key_filename = argv[optind];
+  secret_key = argv[optind];
+  import_keyfile = (access(secret_key, F_OK) == 0);
 
-  log_debug("wordlist: %s\nkey file: %s\n",
+  log_debug("wordlist: %s\n%s: %s\n",
 	    password_filename,
-	    secret_key_filename);
+        import_keyfile? "secret_key_filename": "fingerprint",
+	    secret_key);
 
   if (!(gpg_data.wordlist = fopen(password_filename, "r"))) {
     fprintf(stderr,
@@ -85,13 +91,17 @@ int main(int argc, char *argv[argc])
 	    gpgme_strerror(err));
     exit(gpgme_err_code(err));
   }
-  
+
   log_debug("%s engine supported!\n",
 	    gpgme_get_protocol_name(GPGME_PROTOCOL_OPENPGP));
 
   gpg_data.fingerprint = NULL;
-  if (!bruteforce_gpg_load_secret_key(secret_key_filename, &gpg_data.fingerprint))
-    exit(1);
+  if (import_keyfile) {
+      if (!bruteforce_gpg_import_secret_key(secret_key, &gpg_data.fingerprint))
+          exit(1);
+  } else {
+      gpg_data.fingerprint = strndup(secret_key, 40);
+  }
 
   gpg_data.attempt = 0;
   gpg_data.passphrase = NULL;
@@ -99,7 +109,7 @@ int main(int argc, char *argv[argc])
   workers = calloc(num_threads, sizeof(pthread_t));
   gpg_data.workers = workers;
 
-  
+
   get_gpg_agent_cache_info(&ttl);
   log_debug("Got existing gpg-agent default-cache-ttl: %s\n", ttl);
   set_gpg_agent_cache_info("0");
@@ -118,7 +128,7 @@ int main(int argc, char *argv[argc])
   for (int i = 0; i < num_threads; i++)
     if (pthread_join(workers[i], &worker_err))
       perror("Failed to join to worker thread");
-  
+
   if (gpg_data.passphrase) {
     printf("\nFound passphrase: %s\n", gpg_data.passphrase);
   }
@@ -128,11 +138,15 @@ int main(int argc, char *argv[argc])
   }
   printf("Duration: %lu seconds\n", gpg_data.end_time - start_time);
 
+  // delete imported_key
+  if (import_keyfile) {
+      bruteforce_gpg_delete_secret_key(gpg_data.fingerprint);
+  }
   set_gpg_agent_cache_info(ttl);
   log_debug("Reverted gpg-agent default-cache-ttl to %s\n", ttl);
   free(ttl);
   fclose(gpg_data.wordlist);
   free(gpg_data.fingerprint);
   free(workers);
-  return gpg_data.passphrase != NULL;
+  return gpg_data.passphrase == NULL;   // 0: ok, 1: failure
 }


### PR DESCRIPTION
The existing mode can only support importing secret keys and then bruteforce them. After the completion, the imported keys are deleted from the gpg keyring.
 This PR adds the ability to bruteforce keys that already exist but whose passpharse has been forgotten. e.g.:
```shell
$ bruteforce-gpg -f password.txt E15AAF8A54512F33E55CDF1235705C433A46535C
```